### PR TITLE
It is important that noisy is changed to noisy = double(im2gray(noisy));

### DIFF
--- a/data/HED-BSDS/demo_test_real_data.m
+++ b/data/HED-BSDS/demo_test_real_data.m
@@ -2,6 +2,8 @@ close all
 clear all
 clc
 %load your own data and name it as noisy; 
+    %noisy = imread(filename)
+    noisy = double(im2gray(noisy));
     I=noisy;
     [M_data,N_data]=size(noisy);
     data_final=zeros(M_data,N_data,6);


### PR DESCRIPTION
With just imread, the script returned strange results and the whole of Matlab crashed for bigger images. RGB2gray doesn't work for gray images, therefore im2gray.